### PR TITLE
Specify encoding for stdin.write()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "sybase-charset-tz",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sybase-charset-tz",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "JSONStream": "latest",
-        "my-package": "^0.0.0"
+        "JSONStream": "latest"
       },
       "devDependencies": {
         "bluebird": "^3.4.6",
@@ -366,11 +365,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
-    },
-    "node_modules/my-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/my-package/-/my-package-0.0.0.tgz",
-      "integrity": "sha1-ApAg8n/PKu1HVMUFmrGwnlEHqd4="
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "sybase-charset-tz",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Changed to use JTDS JDBC driver, added charset and timezone parameter to node-sybase. Original node-sybase: A simple node.js wrapper around a java/jconnect app that provides easy access to Sybase Databases without having to install odbc or freetds.",
   "dependencies": {
-    "JSONStream": "latest",
-    "my-package": "^0.0.0"
+    "JSONStream": "latest"
   },
   "main": "src/SybaseDB.js",
   "scripts": {

--- a/src/SybaseDB.js
+++ b/src/SybaseDB.js
@@ -94,7 +94,7 @@ Sybase.prototype.query = function (dbId, sql, callback) {
 
     this.currentMessages[msg.msgId] = msg;
 
-    this.javaDB.stdin.write(strMsg + "\n");
+    this.javaDB.stdin.write(strMsg + "\n", this.encoding);
     this.log("sql request written: " + strMsg);
 };
 


### PR DESCRIPTION
Specify stdin.write() to use our encoding. (Which we will pass in encoding='binary' to let nodejs keep our string data as-is)
Otherwise the default encoding 'utf8' will mess up our data which is already converted to other encoding (e.g. 'big5')